### PR TITLE
update the start time to 18:15

### DIFF
--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -171,7 +171,7 @@ class EventController extends BaseDoctrineController
         if ($form->isSubmitted() && $form->isValid()) {
             $identifier = IdentifierHelper::getHumanReadableIdentifier($event->getTitle());
             $event->setIdentifier($identifier);
-            $event->getStartDate()->setTime(17, 15);
+            $event->getStartDate()->setTime(18, 15);
 
             $this->fastSave($event);
 


### PR DESCRIPTION
As ETH has decided to spread out lectures more, and because laboratory courses exist, many people cannot attend our talks if they start at 17:15. This is why we decided to start all courses at 18:15.